### PR TITLE
make type tester text slightly smaller by default, tweak padding

### DIFF
--- a/_includes/singlefile2.html
+++ b/_includes/singlefile2.html
@@ -31,7 +31,7 @@
   #singleFile #controls-result {
     background: white;
     color: black;
-    font-size: 16vw;
+    font-size: 12vw;
     font-weight: 800;
     line-height: 1.125;
     border: 0px;
@@ -264,14 +264,6 @@
   let slnt2 = 0;
   let ital2 = 0.5;
   document.getElementById("fontSizeSlider").addEventListener("input", function() {
-    // if (window.innerWidth > 767.98){
-    //   document.getElementById("controls-result").style.fontSize = document.getElementById('fontSizeSlider').value + 'vw';
-    // } else {
-    //   document.getElementById("controls-result").style.fontSize = document.getElementById('fontSizeSlider').value * 9 + 60 + 'px';
-    // }
-    // document.getElementById("fontSizeResult").innerHTML = document.getElementById('fontSizeSlider').value + 'vw';
-    // document.getElementById("fontSizeResultSm").innerHTML = Math.floor(document.getElementById('fontSizeSlider').value * 16 + 44) + 'px';
-    // document.getElementById("controls-result").style.fontSize = document.getElementById('fontSizeSlider').value + 'vw';
     if (window.innerWidth > 767.98) {
       document.getElementById("controls-result").style.fontSize = document.getElementById("fontSizeSlider").value + "vw";
       document.getElementById("fontSizeResult").innerHTML = document.getElementById("fontSizeSlider").value + "vw";

--- a/_site/index.html
+++ b/_site/index.html
@@ -420,7 +420,7 @@ To meet the needs of global communication, Recursive supports a wide range of La
   #singleFile #controls-result {
     background: white;
     color: black;
-    font-size: 16vw;
+    font-size: 12vw;
     font-weight: 800;
     line-height: 1.125;
     border: 0px;
@@ -540,14 +540,14 @@ To meet the needs of global communication, Recursive supports a wide range of La
   }
 </style>
 
-<input type="text" value="trialSection" id="controls-result" />
+<input type="text" value="trialSegment" id="controls-result" />
 <div class="controls noWhiteSpace">
   <ul class="central-column">
     <li id="font-size">
       <div class="ccs-row">
         <!-- 767.98px -->
         <div class="css d-none d-md-inline">
-          <span class="property">font-size</span>: <span id="fontSizeResult" contenteditable="true">14vw</span><span class="hidden--sm">;</span>
+          <span class="property">font-size</span>: <span id="fontSizeResult" contenteditable="true">12vw</span><span class="hidden--sm">;</span>
         </div>
         <!-- <div class="css d-md-none">
                         <span class="property">font-size</span>: <span id="fontSizeResultSm" contenteditable="true">300px</span><span class="hidden--sm">;</span>
@@ -640,14 +640,6 @@ To meet the needs of global communication, Recursive supports a wide range of La
   let slnt2 = 0;
   let ital2 = 0.5;
   document.getElementById("fontSizeSlider").addEventListener("input", function() {
-    // if (window.innerWidth > 767.98){
-    //   document.getElementById("controls-result").style.fontSize = document.getElementById('fontSizeSlider').value + 'vw';
-    // } else {
-    //   document.getElementById("controls-result").style.fontSize = document.getElementById('fontSizeSlider').value * 9 + 60 + 'px';
-    // }
-    // document.getElementById("fontSizeResult").innerHTML = document.getElementById('fontSizeSlider').value + 'vw';
-    // document.getElementById("fontSizeResultSm").innerHTML = Math.floor(document.getElementById('fontSizeSlider').value * 16 + 44) + 'px';
-    // document.getElementById("controls-result").style.fontSize = document.getElementById('fontSizeSlider').value + 'vw';
     if (window.innerWidth > 767.98) {
       document.getElementById("controls-result").style.fontSize = document.getElementById("fontSizeSlider").value + "vw";
       document.getElementById("fontSizeResult").innerHTML = document.getElementById("fontSizeSlider").value + "vw";

--- a/_site/singlefile/index.html
+++ b/_site/singlefile/index.html
@@ -94,7 +94,7 @@
   #singleFile #controls-result {
     background: white;
     color: black;
-    font-size: 16vw;
+    font-size: 12vw;
     font-weight: 800;
     line-height: 1.125;
     border: 0px;
@@ -214,14 +214,14 @@
   }
 </style>
 
-<input type="text" value="trialSection" id="controls-result" />
+<input type="text" value="trialSegment" id="controls-result" />
 <div class="controls noWhiteSpace">
   <ul class="central-column">
     <li id="font-size">
       <div class="ccs-row">
         <!-- 767.98px -->
         <div class="css d-none d-md-inline">
-          <span class="property">font-size</span>: <span id="fontSizeResult" contenteditable="true">14vw</span><span class="hidden--sm">;</span>
+          <span class="property">font-size</span>: <span id="fontSizeResult" contenteditable="true">12vw</span><span class="hidden--sm">;</span>
         </div>
         <!-- <div class="css d-md-none">
                         <span class="property">font-size</span>: <span id="fontSizeResultSm" contenteditable="true">300px</span><span class="hidden--sm">;</span>
@@ -327,14 +327,6 @@
   let slnt2 = 0;
   let ital2 = 0.5;
   document.getElementById("fontSizeSlider").addEventListener("input", function() {
-    // if (window.innerWidth > 767.98){
-    //   document.getElementById("controls-result").style.fontSize = document.getElementById('fontSizeSlider').value + 'vw';
-    // } else {
-    //   document.getElementById("controls-result").style.fontSize = document.getElementById('fontSizeSlider').value * 9 + 60 + 'px';
-    // }
-    // document.getElementById("fontSizeResult").innerHTML = document.getElementById('fontSizeSlider').value + 'vw';
-    // document.getElementById("fontSizeResultSm").innerHTML = Math.floor(document.getElementById('fontSizeSlider').value * 16 + 44) + 'px';
-    // document.getElementById("controls-result").style.fontSize = document.getElementById('fontSizeSlider').value + 'vw';
     if (window.innerWidth > 767.98) {
       document.getElementById("controls-result").style.fontSize = document.getElementById("fontSizeSlider").value + "vw";
       document.getElementById("fontSizeResult").innerHTML = document.getElementById("fontSizeSlider").value + "vw";


### PR DESCRIPTION
I've adjusted the default word in the type tester to hit a few goals. It was previously "Experiment" and is now "trialSection." This has several advantages:

- On mobile, only the first two or three letters show up. It is important that these letters give show a clear difference when changed from Sans to Mono. "tri" is much better for this than "Ex," in which only the "E" changes very slightly.
- On desktop, it's also nice to have a variety of letters that change shape in the MONO axis. Having a lowercase "a" and "g" in the phrase is also very nice, because these letters have a lot of personality in any font, and they are often how graphic designers judge and remember fonts.
- It's fun that it looks code-like and is self-referential (sort of recursive, in a sense?)