### PR TITLE
pin threeJS version at 0.112.1 to avoid issue #52

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -125,8 +125,8 @@
 		{% include footer.html %}
 
 <!-- Three JS -->
-<script src='https://threejs.org/build/three.min.js'></script>
-<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/three@0.112.1/build/three.min.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/three@0.112.1/examples/js/controls/OrbitControls.js'></script>
 
 <!-- Markdown -->
 <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>

--- a/_site/index.html
+++ b/_site/index.html
@@ -10693,8 +10693,8 @@ Google and the Google Fonts logo are registered trademarks or service marks of G
 </div>
 
 <!-- Three JS -->
-<script src='https://threejs.org/build/three.min.js'></script>
-<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/three@0.112.1/build/three.min.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/three@0.112.1/examples/js/controls/OrbitControls.js'></script>
 
 <!-- Markdown -->
 <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>


### PR DESCRIPTION
This is a quick patch to https://github.com/arrowtype/recursive-minisite/issues/52

However, I suspect the better approach might be to require a pinned version of the threeJS npm module and import that, rather than calling it from a CDN.

Is one approach better or worse than the other?